### PR TITLE
PHP8 Compatibility

### DIFF
--- a/pmpro-invite-only.php
+++ b/pmpro-invite-only.php
@@ -293,7 +293,7 @@ function pmproio_displayInviteCodes($user_id = null, $unused = true, $used = fal
 				if(!empty($user_ids))
 				{
 					$codes_used = true;
-					break;
+					return;
 				}
 		}
 


### PR DESCRIPTION
The break on line 296 results in a fatal error on some PHP8 installations. 

Changing this to return instead resolves the issue. 

Steps to test:

1. Checkout with an Invite Only level
2. Navigate back to the Membership Account
3. No errors should show up on below the list of codes