### PR TITLE
No longer pulling level from $_REQUEST

### DIFF
--- a/pmpro-invite-only.php
+++ b/pmpro-invite-only.php
@@ -438,10 +438,10 @@ function pmproio_pmpro_after_change_membership_level($level_id, $user_id)
 add_action("pmpro_after_change_membership_level", "pmproio_pmpro_after_change_membership_level", 10, 2);
 
 //at checkout
-function pmproio_pmpro_after_checkout($user_id)
+function pmproio_pmpro_after_checkout( $user_id, $order )
 {
 	//get level
-	$level_id = intval($_REQUEST['level']);
+	$level_id = intval( $order->membership_id );
 
 	if(pmproio_isInviteLevel($level_id))
 	{


### PR DESCRIPTION
Should only be merged once this PR is confirmed to be merged into the PMPro v3.0 branch: https://github.com/strangerstudios/paid-memberships-pro/pull/2506

This PR specifically stops pulling the checkout level from the `$_REQUEST` variable (since we are prefixing the `level` parameter in 3.0) and instead uses the `pmpro_getLevelAtCheckout()` function.